### PR TITLE
Fix husky preventing installing the package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0]
+## [0.6.1]
+
+### Fixed
+
+- Uh, after adding husky, the package wouldn't install anymore, so I fixed that!
+
+## [0.6.0] ⚠️ SKIP THIS RELEASE
+
+**IMPORTANT**: This release cannot be installed due to `husky install` being run in the `postinstall` script instead of `prepare`. As such, please upgrade to the 0.6.1 release ASAP.
 
 **WARNING**: This release contains a lot of breaking changes due to the fact that Umami's API moved from using IDs to UUIDs for most operations. As such, you should update your code to use UUIDs instead of IDs. Also, some parameters changed from `snake_case` to `camelCase`, due to changes in the Umami API. Sadly, it's not super consistent, so some items still require `snake_case`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "umami-api",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "umami-api",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"types": "./dist/index.d.ts",
 	"scripts": {
 		"setup": "npm install -g microbundle",
-		"postinstall": "husky install",
+		"prepare": "husky install",
 		"prepublish": "npm run build",
 		"build": "microbundle",
 		"dev": "microbundle watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "umami-api",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "A simple API client for Umami analytics",
 	"author": "Jakob Bouchard <jakob@jakobbouchard.dev>",
 	"license": "MIT",


### PR DESCRIPTION
After adding husky to the project in the `postinstall` script, the package cannot be installed anymore since husky is only installed during dev. This puts husky in the `prepare` script instead, to prevent this issue.